### PR TITLE
Fix data rebasing

### DIFF
--- a/launch-cache/CacheFileAbstraction.hpp
+++ b/launch-cache/CacheFileAbstraction.hpp
@@ -92,6 +92,14 @@ public:
 	uint64_t		imagesTextCount() const					INLINE { return E::get64(fields.imagesTextCount); }
 	void			set_imagesTextCount(uint64_t value)		INLINE { E::set64(fields.imagesTextCount, value); }
 
+	//TODO: Other accessors?
+
+	uint32_t		mappingWithSlideOffset() const			INLINE { return E::get32(fields.mappingWithSlideOffset); }
+	void			set_mappingWithSlideOffset(uint32_t value)		INLINE { E::set32(fields.mappingWithSlideOffset, value); }
+
+	uint32_t		mappingWithSlideCount() const					INLINE { return E::get32(fields.mappingWithSlideCount); }
+	void			set_mappingWithSlideCount(uint32_t value)		INLINE { E::set32(fields.mappingWithSlideCount, value); }
+
 private:
 	dyld_cache_header			fields;
 };

--- a/launch-cache/dsc_extractor.cpp
+++ b/launch-cache/dsc_extractor.cpp
@@ -233,10 +233,10 @@ static void rebaseChain(uint8_t* pageContent, uint16_t startOffset, uintptr_t sl
             if (*((uintptr_t*)outLoc) != rawValue) {
                 //This shouldn't happen, and I'm not sure why it does
                 //but when it does, it tends to produce invalid libraries
-                printf("Warning: rawValue doesn't match value at outLoc\n");
-                printf("outLoc: %p\n", outLoc);
-                printf("*outloc: %p\n", *((uintptr_t*)outLoc));
-                printf("rawValue: %p\n", (void*)rawValue);
+                // printf("Warning: rawValue doesn't match value at outLoc\n");
+                // printf("outLoc: %p\n", outLoc);
+                // printf("*outloc: %p\n", *((uintptr_t*)outLoc));
+                // printf("rawValue: %p\n", (void*)rawValue);
                 skipped++;
                 // abort();
             }else

--- a/launch-cache/dsc_extractor.cpp
+++ b/launch-cache/dsc_extractor.cpp
@@ -40,7 +40,7 @@
 #include "CodeSigningTypes.h"
 #include <CommonCrypto/CommonHMAC.h>
 #include <CommonCrypto/CommonDigest.h>
-#include "CommonDigestSPI.h"
+#include <CommonCrypto/CommonDigestSPI.h>
 
 #define NO_ULEB
 #include "Architectures.hpp"
@@ -59,9 +59,6 @@
 #include <unordered_map>
 #include <algorithm>
 #include <dispatch/dispatch.h>
-
-#include <string>
-#include <mach/mach.h>
 
 struct seg_info
 {
@@ -113,33 +110,6 @@ private:
     }
     const std::set<int> &_reexportDeps;
 };
-
-template <typename A>
-int fixupObjc(macho_header<typename A::P>* mh, uint64_t textOffsetInCache, const void* mapped_cache) {
-   typedef typename A::P P;
-    const macho_section<P>* methnameSec = mh->getSection("__TEXT", "__objc_methname");
-    if (methnameSec) {
-        // method name to in-memory address
-        std::unordered_map<std::string, uint64_t> methnameToAddr;
-        for (uint64_t off = 0; off < methnameSec->size();) {
-            const char* methname = (const char*)mh + methnameSec->offset() + off;
-            methnameToAddr[methname] = methnameSec->addr() + off;
-            off += strlen(methname) + 1;
-        }
-        if (methnameToAddr.size() > 0) {
-            const macho_section<P>* selrefsSec = mh->getSection("__DATA", "__objc_selrefs");
-            if (selrefsSec) {
-                uint64_t* selrefsArr = (uint64_t*)(((char*)mh) + selrefsSec->offset());
-                for (uint64_t index = 0; index < selrefsSec->size() / sizeof(uint64_t); index++) {
-                    uint64_t selref = selrefsArr[index];
-                    const char* origStr = (const char*)mapped_cache + (selref & 0xffffffffffULL);
-                    selrefsArr[index] = methnameToAddr[origStr];
-                }
-            }
-        }
-    }
-    return 0;
-}
 
 template <typename P>
 struct LoadCommandInfo {
@@ -264,7 +234,7 @@ public:
         mh->set_sizeofcmds(origLoadCommandsSize - bytesRemaining);
     }
 
-    int optimize_linkedit(macho_header<typename A::P>* mh, std::vector<uint8_t> &new_linkedit_data, uint64_t textOffsetInCache, const void* mapped_cache)
+    int optimize_linkedit(std::vector<uint8_t> &new_linkedit_data, uint64_t textOffsetInCache, const void* mapped_cache)
     {
         typedef typename A::P P;
         typedef typename A::P::E E;
@@ -479,8 +449,6 @@ public:
         linkEditSegCmd->set_filesize(symtab->stroff()+symtab->strsize() - linkEditSegCmd->fileoff());
         linkEditSegCmd->set_vmsize( (linkEditSegCmd->filesize()+4095) & (-4096) );
 
-        fixupObjc<A>(mh, textOffsetInCache, mapped_cache);
-
         // <rdar://problem/17671438> Xcode 6 leaks in dyld_shared_cache_extract_dylibs
         for (std::vector<mach_o::trie::Entry>::iterator it = exports.begin(); it != exports.end(); ++it) {
             ::free((void*)(it->name));
@@ -552,7 +520,7 @@ void dylib_maker(const void* mapped_cache, std::vector<uint8_t> &dylib_data, con
     LinkeditOptimizer<A> linkeditOptimizer;
     macho_header<P>* mh = (macho_header<P>*)&new_dylib_data.front();
     linkeditOptimizer.optimize_loadcommands(mh);
-    linkeditOptimizer.optimize_linkedit(mh, new_linkedit_data, textOffsetInCache, mapped_cache);
+    linkeditOptimizer.optimize_linkedit(new_linkedit_data, textOffsetInCache, mapped_cache);
 
     new_dylib_data.insert(new_dylib_data.end(), new_linkedit_data.begin(), new_linkedit_data.end());
 
@@ -794,11 +762,6 @@ int dyld_shared_cache_extract_dylibs_progress(const char* shared_cache_file_path
         fprintf(stderr, "Error: failed to open shared cache file at %s\n", shared_cache_file_path);
         return -1;
     }
-
-    if (fcntl(cache_fd, F_NOCACHE, 1) == -1) {
-         fprintf(stderr, "nocache failed\n");
-         return -1;
-     }
 
     void* mapped_cache = mmap(NULL, (size_t)statbuf.st_size, PROT_READ, MAP_PRIVATE, cache_fd, 0);
     if (mapped_cache == MAP_FAILED) {

--- a/launch-cache/dsc_extractor.cpp
+++ b/launch-cache/dsc_extractor.cpp
@@ -40,7 +40,7 @@
 #include "CodeSigningTypes.h"
 #include <CommonCrypto/CommonHMAC.h>
 #include <CommonCrypto/CommonDigest.h>
-// #include <CommonCrypto/CommonDigestSPI.h>
+#include "CommonDigestSPI.h"
 
 #define NO_ULEB
 #include "Architectures.hpp"

--- a/launch-cache/dyld_cache_format.h
+++ b/launch-cache/dyld_cache_format.h
@@ -30,28 +30,55 @@
 #include <uuid/uuid.h>
 
 
-struct dyld_cache_header
-{
-	char		magic[16];				// e.g. "dyld_v0    i386"
-	uint32_t	mappingOffset;			// file offset to first dyld_cache_mapping_info
-	uint32_t	mappingCount;			// number of dyld_cache_mapping_info entries
-	uint32_t	imagesOffset;			// file offset to first dyld_cache_image_info
-	uint32_t	imagesCount;			// number of dyld_cache_image_info entries
-	uint64_t	dyldBaseAddress;		// base address of dyld when cache was built
-	uint64_t	codeSignatureOffset;	// file offset of code signature blob
-	uint64_t	codeSignatureSize;		// size of code signature blob (zero means to end of file)
-	uint64_t	slideInfoOffset;		// file offset of kernel slid info
-	uint64_t	slideInfoSize;			// size of kernel slid info
-	uint64_t	localSymbolsOffset;		// file offset of where local symbols are stored
-	uint64_t	localSymbolsSize;		// size of local symbols information
-	uint8_t		uuid[16];				// unique value for each shared cache file
-	uint64_t	cacheType;				// 0 for development, 1 for production
-	uint32_t	branchPoolsOffset;		// file offset to table of uint64_t pool addresses
-	uint32_t	branchPoolsCount;	    // number of uint64_t entries
-	uint64_t	accelerateInfoAddr;		// (unslid) address of optimization info
-	uint64_t	accelerateInfoSize;		// size of optimization info
-	uint64_t	imagesTextOffset;		// file offset to first dyld_cache_image_text_info
-	uint64_t	imagesTextCount;		// number of dyld_cache_image_text_info entries
+struct dyld_cache_header {
+    char     magic[16];                 // e.g. "dyld_v0    i386"
+    uint32_t mappingOffset;             // file offset to first dyld_cache_mapping_info
+    uint32_t mappingCount;              // number of dyld_cache_mapping_info entries
+    uint32_t imagesOffset;              // file offset to first dyld_cache_image_info
+    uint32_t imagesCount;               // number of dyld_cache_image_info entries
+    uint64_t dyldBaseAddress;           // base address of dyld when cache was built
+    uint64_t codeSignatureOffset;       // file offset of code signature blob
+    uint64_t codeSignatureSize;         // size of code signature blob (zero means to end of file)
+    uint64_t slideInfoOffset;           // file offset of kernel slid info
+    uint64_t slideInfoSize;             // size of kernel slid info
+    uint64_t localSymbolsOffset;        // file offset of where local symbols are stored
+    uint64_t localSymbolsSize;          // size of local symbols information
+    uint8_t  uuid[16];                  // unique value for each shared cache file
+    uint64_t cacheType;                 // 0 for development, 1 for production
+    uint32_t branchPoolsOffset;         // file offset to table of uint64_t pool addresses
+    uint32_t branchPoolsCount;          // number of uint64_t entries
+    uint64_t accelerateInfoAddr;        // (unslid) address of optimization info
+    uint64_t accelerateInfoSize;        // size of optimization info
+    uint64_t imagesTextOffset;          // file offset to first dyld_cache_image_text_info
+    uint64_t imagesTextCount;           // number of dyld_cache_image_text_info entries
+    uint64_t patchInfoAddr;             // (unslid) address of dyld_cache_patch_info
+    uint64_t patchInfoSize;             // Size of all of the patch information pointed to via the dyld_cache_patch_info
+    uint64_t otherImageGroupAddrUnused; // unused
+    uint64_t otherImageGroupSizeUnused; // unused
+    uint64_t progClosuresAddr;          // (unslid) address of list of program launch closures
+    uint64_t progClosuresSize;          // size of list of program launch closures
+    uint64_t progClosuresTrieAddr;      // (unslid) address of trie of indexes into program launch closures
+    uint64_t progClosuresTrieSize;      // size of trie of indexes into program launch closures
+    uint32_t platform;                  // platform number (macOS=1, etc)
+    uint32_t formatVersion : 8,         // dyld3::closure::kFormatVersion
+        dylibsExpectedOnDisk : 1,       // dyld should expect the dylib exists on disk and to compare inode/mtime to see if cache is valid
+        simulator : 1,                  // for simulator of specified platform
+        locallyBuiltCache : 1,          // 0 for B&I built cache, 1 for locally built cache
+        builtFromChainedFixups : 1,     // some dylib in cache was built using chained fixups, so patch tables must be used for overrides
+        padding : 20;                   // TBD
+    uint64_t sharedRegionStart;         // base load address of cache if not slid
+    uint64_t sharedRegionSize;          // overall size of region cache can be mapped into
+    uint64_t maxSlide;                  // runtime slide of cache can be between zero and this value
+    uint64_t dylibsImageArrayAddr;      // (unslid) address of ImageArray for dylibs in this cache
+    uint64_t dylibsImageArraySize;      // size of ImageArray for dylibs in this cache
+    uint64_t dylibsTrieAddr;            // (unslid) address of trie of indexes of all cached dylibs
+    uint64_t dylibsTrieSize;            // size of trie of cached dylib paths
+    uint64_t otherImageArrayAddr;       // (unslid) address of ImageArray for dylibs and bundles with dlopen closures
+    uint64_t otherImageArraySize;       // size of ImageArray for dylibs and bundles with dlopen closures
+    uint64_t otherTrieAddr;             // (unslid) address of trie of indexes of all dylibs and bundles with dlopen closures
+    uint64_t otherTrieSize;             // size of trie of dylibs and bundles with dlopen closures
+    uint32_t mappingWithSlideOffset;    // file offset to first mapping info with a slide offset
+    uint32_t mappingWithSlideCount;     // number of mapping info entries
 };
 
 

--- a/launch-cache/dyld_cache_format.h
+++ b/launch-cache/dyld_cache_format.h
@@ -90,6 +90,20 @@ struct dyld_cache_mapping_info {
 	uint32_t	initProt;
 };
 
+
+// These appear to be identical to dyld_shared_cache_mapping_info
+// Except they've got offsets and sizes of slide info
+typedef struct {
+    uint64_t address;
+    uint64_t size;
+    uint64_t fileOffset;
+    uint64_t slide_info_off;
+    uint64_t slide_info_size;
+    char     skip_0x10[8];
+    uint32_t maxProt;
+    uint32_t initProt;
+} dyld_cache_slide_descriptor;
+
 struct dyld_cache_image_info
 {
 	uint64_t	address;


### PR DESCRIPTION
Per discussion in #2 here are the changes I've made. I don't know if its useful or not, but feel free to disregard if it isn't. I think it should fix up the objective-c things you were already doing, but should more generically fix up pointers found in `__DATA` as well as symbols.

Here are some notes:

- My c++ is terrible; I'm really sorry
- This is an adaptation of the work done in https://github.com/zhuowei/dsc_extractor_badly
- The important, but not obvious parts are changes made to structures in `launch-cache/dyld_cache_format.h`, especially location of undocumented mapping structs that point to slide info structs
- There is a bunch of stuff that this doesn't do correctly, including:
  - There are broken references from `__TEXT` to `__DATA`
  - Some libraries, such as `libswiftSceneKit` are almost complete nonsense
- It would be worth looking at the objective-c stuff in `dsc_extractor_badly`, as I didn't integrate that. The specific library I cared about wasn't obj-c

Let me know if I can help or if there are things here I can help explain